### PR TITLE
issue/1: support one-argument `bless`

### DIFF
--- a/lib/Acme/Undead.pm
+++ b/lib/Acme/Undead.pm
@@ -82,7 +82,7 @@ sub _bless {
   my $hinthash = (caller(0))[10];
   return $hinthash->{acme_undead} ? die('blessed') : do {
     my $arg = shift;
-    my $pkg = shift;
+    my $pkg = shift || (caller(0))[0];
     bless($arg, $pkg);
   }
 }


### PR DESCRIPTION
support one-argument `bless` when `no Acme::Undead`

```perl
use Acme::Undead
no Acme::Undead
my $self = bless {}; # blessed this package name.
```