### PR TITLE
issue/2: add requires `Test::Exception` on test.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,5 +2,6 @@ requires 'perl', '5.008001';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';
+    requires 'Test::Exception';
 };
 


### PR DESCRIPTION
`Test::Exception` is not standard at perl version and on OS